### PR TITLE
Port to tokio 0.2 / reqwest 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,10 @@ log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-futures = "0.3"
-futures-timer = "1.0"
 async-trait = "0.1"
 jsonwebtoken = "6.0"
-surf = "1.0"
+reqwest = { version = "0.10", features = ["json"] }
 r2d2_redis = "0.12"
 chrono = "0.4"
 svc-authn = { version = "0.5", features = ["jose"] }
+tokio = { version = "0.2", features = ["time"] }


### PR DESCRIPTION
This PR contains a port from `surf` HTTP client to `reqwest` as well as from `futures-timer` to `tokio::time`. It provides for lower resource consumption and also removes dependency on libcurl.

Also included are several style fixes as suggested by clippy.